### PR TITLE
Fix bug with max_step_count

### DIFF
--- a/stoqcompiler/compiler/compiler.py
+++ b/stoqcompiler/compiler/compiler.py
@@ -177,9 +177,9 @@ class Compiler:
         compiled_sequence = UnitarySequence(self.dimension)
         cost_by_step = []
 
-        while not (
-                compiled_sequence.product().close_to(target_unitary, threshold)
-                and len(cost_by_step) < max_step_count):
+        while (not compiled_sequence.product().close_to(
+                target_unitary, threshold)
+               and len(cost_by_step) < max_step_count):
             self.beta = min(self.beta + self.annealing_rate, self.max_beta)
             product_before_change = compiled_sequence.product()
             self._make_random_change(compiled_sequence)


### PR DESCRIPTION
Logic error accidentally introduced when adding parentheses for PEP8 formatting.