### PR TITLE
Fix bug in Unitary.close_to

### DIFF
--- a/stoqcompiler/unitary/unitary.py
+++ b/stoqcompiler/unitary/unitary.py
@@ -296,7 +296,7 @@ class Unitary:
         :rtype: bool
         '''
         distance = self.distance_from(u)
-        if threshold:
+        if threshold is not None:
             max_distance = 1.0 - threshold
             return distance <= max_distance
 

--- a/tests/test_unitary.py
+++ b/tests/test_unitary.py
@@ -22,6 +22,20 @@ class TestUnitary:
         assert unitary.get_dimension() == dimension
         assert unitary.close_to(np.identity(dimension))
 
+    def test_close_to(self) -> None:
+        dimension = 2
+        random_unitary = Unitary.random(dimension)
+        t = UnitaryDefinitions.t()
+
+        assert random_unitary.close_to(random_unitary)
+        assert random_unitary.close_to(random_unitary, None)
+        assert random_unitary.close_to(random_unitary, 0.999)
+
+        assert not random_unitary.close_to(t)
+        assert not random_unitary.close_to(t, None)
+        assert not random_unitary.close_to(t, 0.999)
+        assert random_unitary.close_to(t, 0.0)
+
     def test_non_square_matrix(self) -> None:
         dimension = 2
         with pytest.raises(Exception):


### PR DESCRIPTION
Fixing a bug where `threshold = 0.0` was treated as `None` in the implementation of `Unitary.close_to`. Also adding a test to verify the fix.

Thanks to @edyrenkova for finding this.